### PR TITLE
WEB-7143 - Corrige campo nosso_numero do retorno Bradesco CNAB 400

### DIFF
--- a/cnab400/237/retorno/detalhe.yml
+++ b/cnab400/237/retorno/detalhe.yml
@@ -33,8 +33,12 @@ zeros03:
   picture: '9(8)'
 
 nosso_numero:
-  pos: [71, 82]
-  picture: '9(12)'
+  pos: [71, 81]
+  picture: '9(11)'
+
+dac_nosso_numero:
+  pos: [82, 82]
+  picture: '9(01)'
 
 uso_banco01:
   pos: [83, 92]


### PR DESCRIPTION
Separa o campo de 12 posições em nosso_numero (11 chars) e dac_nosso_numero (1 char), seguindo o mesmo padrão do Itaú. O campo incluía o DAC junto ao nosso número, causando falha silenciosa na busca do boleto ao importar arquivo de retorno.

